### PR TITLE
Add CMake install step for build results

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,14 @@ endif ()
 set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 #################################################################################
+# INSTALL
+#################################################################################
+
+install (TARGETS ${PROJECT_NAME} DESTINATION lib)
+install (DIRECTORY ${BS_DIR_INC}/common/instrumentation/api/
+    DESTINATION include FILES_MATCHING PATTERN "*.h")
+
+#################################################################################
 # DEBUG
 #################################################################################
 


### PR DESCRIPTION
Added CMake install step for API headers and built a library so that
automated build tools like autospec can handle installation steps.

Signed-off-by: Brandon Hong <brandon.hong@intel.com>