### PR TITLE
cmake: Set lib version property based on header data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,12 @@ endif ()
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
+if ("${PLATFORM}" STREQUAL "linux")
+    set_metrics_discovery_version()
+    set_property(TARGET ${PROJECT_NAME} PROPERTY VERSION ${MD_VERSION})
+    set_property(TARGET ${PROJECT_NAME} PROPERTY SOVERSION ${MD_VERSION_MAJOR})
+endif()
+
 #################################################################################
 # INSTALL
 #################################################################################
@@ -217,6 +223,7 @@ install (FILES "${BS_DIR_INC}/common/instrumentation/api/metrics_discovery_api.h
 #################################################################################
 
 message ("INFO: PROJECT_NAME           = ${PROJECT_NAME}")
+message ("INFO: VERSION                = ${MD_VERSION}")
 message ("INFO: BUILD_TYPE             = ${BUILD_TYPE}")
 message ("INFO: PLATFORM               = ${PLATFORM}")
 message ("INFO: ARCH                   = ${ARCH}")

--- a/md_cmake_adapter.cmake
+++ b/md_cmake_adapter.cmake
@@ -22,6 +22,25 @@
 # HELPER FUNCTIONS
 #################################################################################
 
+##################################################################################
+# set_metrics_discovery_version
+#   Finds version string based on the API version enums in metrics_discovery_api.h
+#   and sets variables MD_VERSION_MAJOR and MD_VERSION in parent context
+##################################################################################
+function(set_metrics_discovery_version)
+    # parse the full version number from metrics_discovery_api.h and set MD_VERSION
+    file(READ ${CMAKE_CURRENT_SOURCE_DIR}/inc/common/instrumentation/api/metrics_discovery_api.h _md_h_contents)
+
+    foreach(VERSION MAJOR MINOR BUILD)
+        string(REGEX MATCH "MD_API_${VERSION}_NUMBER_CURRENT[ \t]*=*[\ t]*[A-Z_]*[0-9]*" _ENUM_LINE ${_md_h_contents})
+        string(REGEX MATCH "[0-9].*" VERSION_NUMBER ${_ENUM_LINE})
+        set(VERSION_${VERSION} ${VERSION_NUMBER})
+    endforeach(VERSION)
+
+    set(MD_VERSION_MAJOR ${VERSION_MAJOR} PARENT_SCOPE)
+    set(MD_VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD} PARENT_SCOPE)
+endfunction(set_metrics_discovery_version)
+
 #################################################################################
 # clearInputVariables
 #   Clears cached MDAPI input cmake variables. Needed for e.g. the below command scenario:


### PR DESCRIPTION
The file metrics_discovery_api.h contains information about
the lib version in enums. This patch takes that data and
sets the library version and soname. With such properties set,
cmake performs the tasks needed to generate a versioned lib file
(e.g. .so.MAJOR.MINOR.BUILD on Linux) in addition to the
non-versioned lib file (e.g. .so symbolic link on Linux).
These files are required by many Linux distributions that split
content in core and -dev packages.

Signed-off-by: Anselmo L. S. Melo <anselmo.melo@intel.com>