### PR TITLE
Fix: Locate header file under mdapi directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,7 @@ set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 #################################################################################
 
 install (TARGETS ${PROJECT_NAME} DESTINATION lib)
-install (FILES "${BS_DIR_INC}/common/instrumentation/api/metrics_discovery_api.h" DESTINATION include)
+install (FILES "${BS_DIR_INC}/common/instrumentation/api/metrics_discovery_api.h" DESTINATION include/mdapi)
 
 #################################################################################
 # DEBUG


### PR DESCRIPTION
This patch changes target directory of the metrics_discovery_api.h file
to /usr/loca/include/mdapi instead of /usr/local/include.

Signed-off-by: Brandon Hong <brandon.hong@intel.com>