### PR TITLE
md_internal.h: Replace string.h with <string> C++ header API

### DIFF
--- a/instrumentation/metrics_discovery/common/md_internal.cpp
+++ b/instrumentation/metrics_discovery/common/md_internal.cpp
@@ -27,8 +27,8 @@
 \*****************************************************************************/
 #include "md_internal.h"
 
-#include <string.h>
 #include <stdlib.h>
+#include <string>
 #include <new>
 #include <unordered_map>
 


### PR DESCRIPTION
This helps in compiling with libc++/Clang
Fixes
usr/include/c++/v1/type_traits:1561:38: error: implicit instantiation of undefined template 'std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >'
: public integral_constant<bool, __is_empty(_Tp)> {};
^

Signed-off-by: Khem Raj <raj.khem@gmail.com>